### PR TITLE
Don't handle nil actions in navigation middleware

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -35,6 +35,10 @@ function createReactNavigationReduxMiddleware<State: {}>(
   key?: string = "root",
 ): Middleware<State, *, *> {
   return store => next => action => {
+    if (!action) {
+      return
+    }
+
     const oldState = store.getState();
     const result = next(action);
     const newState = store.getState();


### PR DESCRIPTION
The use case is when you have custom action creator attached to router with "getCustomActionCreators" config property, but it doesn't alway return an action. 

Example is "handleLink" function which takes `url` argument, validates it and, if it is a valid deep link, updates the navigation state, but, if url starts with `https://`, it opens it in `WebBrowser` and doesn't return any action. There are other use cases (we have many custom action creators), but this is the main.

To fix it today, we need to always return empty action from each custom action creator.

P.S. `react-navigation` routers already skip nil actions and don't call `getStateForAction`. So, I guess this package should follow general practice too.